### PR TITLE
Add commands to move to speakers

### DIFF
--- a/simgui.json
+++ b/simgui.json
@@ -16,6 +16,11 @@
       "/SmartDashboard/VisionSystemSim-main/Sim Field": "Field2d"
     },
     "windows": {
+      "/FMSInfo": {
+        "window": {
+          "visible": true
+        }
+      },
       "/SmartDashboard/Field": {
         "bottom": 1476,
         "height": 8.210550308227539,
@@ -41,15 +46,8 @@
     }
   },
   "NetworkTables": {
-    "Persistent Values": {
-      "open": false
-    },
-    "Retained Values": {
-      "open": false
-    },
     "transitory": {
       "CameraPublisher": {
-        "open": true,
         "photonvision-processed": {
           "open": true,
           "string[]##v_/CameraPublisher/photonvision-processed/streams": {
@@ -62,6 +60,9 @@
             "open": true
           }
         }
+      },
+      "FMSInfo": {
+        "open": true
       },
       "PathPlanner": {
         "double[]##v_/PathPlanner/activePath": {

--- a/simgui.json
+++ b/simgui.json
@@ -55,6 +55,12 @@
           "string[]##v_/CameraPublisher/photonvision-processed/streams": {
             "open": true
           }
+        },
+        "photonvision-raw": {
+          "open": true,
+          "string[]##v_/CameraPublisher/photonvision-raw/streams": {
+            "open": true
+          }
         }
       },
       "PathPlanner": {

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -10,13 +10,15 @@ import edu.wpi.first.apriltag.AprilTagFieldLayout;
 import edu.wpi.first.apriltag.AprilTagFields;
 import edu.wpi.first.math.Matrix;
 import edu.wpi.first.math.VecBuilder;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Rotation3d;
 import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.geometry.Translation3d;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
-import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
+import edu.wpi.first.units.Units;
 import swervelib.math.Matter;
 import swervelib.parser.PIDFConfig;
 
@@ -38,8 +40,11 @@ public final class Constants {
           new CommandXboxController(DriveteamConstants.kOperatorControllerPort);
   
   public static final double ROBOT_MASS = (100) * 0.453592; // 32lbs * kg per pound***Need to change
-  public static final Matter CHASSIS    = new Matter(new Translation3d(0, 0, Units.inchesToMeters(8)), ROBOT_MASS);
+  // public static final Matter CHASSIS    = new Matter(new Translation3d(0, 0, Units.inchesToMeters(8)), ROBOT_MASS);
   public static final double LOOP_TIME  = 0.13; //s, 20ms + 110ms sprk max velocity lag
+
+  public static final Pose2d BLUE_SPEAKER = new Pose2d(Units.Meters.of(3), Units.Meters.of(5.77), Rotation2d.fromDegrees(130.0));
+  public static final Pose2d RED_SPEAKER = new Pose2d(Units.Meters.of(14), Units.Meters.of(5.77), Rotation2d.fromDegrees(330.0));
 
   // CONTROL CONSTANT CLASSES
 

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -46,6 +46,9 @@ public final class Constants {
   public static final Pose2d BLUE_SPEAKER = new Pose2d(Units.Meters.of(3), Units.Meters.of(5.77), Rotation2d.fromDegrees(130.0));
   public static final Pose2d RED_SPEAKER = new Pose2d(Units.Meters.of(14), Units.Meters.of(5.77), Rotation2d.fromDegrees(330.0));
 
+  public static final int BLUE_SPEAKER_TAG_INDEX = 3;
+  public static final int RED_SPEAKER_TAG_INDEX = 8;
+
   // CONTROL CONSTANT CLASSES
 
   public static class Vision {

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -52,7 +52,7 @@ public final class Constants {
   // CONTROL CONSTANT CLASSES
 
   public static class Vision {
-      public static final String kCameraName = "photonvision";
+      public static final String kCameraName = "HD_Webcam_C615";
       // Cam mounted facing forward, half a meter forward of center, half a meter up from center.
       public static final Transform3d kRobotToCam =
               new Transform3d(new Translation3d(0.5, 0.0, 0.5), new Rotation3d(0, 0, 0));

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -7,11 +7,13 @@ package frc.robot;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
+import frc.robot.subsystems.Vision.VisionSubsystem;
 //import frc.robot.subsystems.LED.LEDSubsystem;
 import edu.wpi.first.wpilibj.Filesystem;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.simulation.BatterySim;
 import edu.wpi.first.wpilibj.simulation.RoboRioSim;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -73,6 +73,7 @@ public class Robot extends TimedRobot {
     // and running subsystem periodic() methods.  This must be called from the robot's periodic
     // block in order for anything in the Command-based framework to work.
     CommandScheduler.getInstance().run();
+    m_robotContainer.m_drivebase.updateEstimatedPose(m_robotContainer.m_vision);
   }
 
   /** This function is called once each time the robot enters Disabled mode. */

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -62,9 +62,6 @@ public class RobotContainer {
   private Pose2d curentSpeakerPose;
   private int currentSpeakerTagIndex;
 
-  private final proximitysubsystem m_proximity = new proximitysubsystem();
-  
-  
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
   public RobotContainer() {
     configurePathPlanner();

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -45,15 +45,11 @@ public class RobotContainer {
 
 
   public final SwerveSubsystem m_drivebase = SwerveSubsystem.getInstance();
-  public final VisionSubsystem m_vision = new VisionSubsystem();
+  public final VisionSubsystem m_vision = VisionSubsystem.getInstance();
 
   private final SendableChooser<Command> autoChooser;
 
-   private final proximitysubsystem m_proximity = new proximitysubsystem();
-  
-  private final SwerveSubsystem m_drivebase = SwerveSubsystem.getInstance();
-
-  private final SendableChooser<Command> autoChooser;
+  //  private final proximitysubsystem m_proximity = new proximitysubsystem();
   
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
   public RobotContainer() {
@@ -74,8 +70,8 @@ public class RobotContainer {
    */
   private void configureBindings() {
 
-     Constants.operatorController.b().or(Constants.driverController.rightTrigger(.1)).or(m_proximity.piecein.whileTrue(m_intake.startIntaking().andThen(m_uptake.startUptaking())));
-     Constants.operatorController.b().or(Constants.driverController.rightTrigger(.1)).or(m_proximity.piecein.whileFalse(m_intake.stopIntaking().andThen((m_uptake.stopUptaking()))));
+    //  Constants.operatorController.b().or(Constants.driverController.rightTrigger(.1)).or(m_proximity.piecein.whileTrue(m_intake.startIntaking().andThen(m_uptake.startUptaking())));
+    //  Constants.operatorController.b().or(Constants.driverController.rightTrigger(.1)).or(m_proximity.piecein.whileFalse(m_intake.stopIntaking().andThen((m_uptake.stopUptaking()))));
 
      Constants.operatorController.x().whileTrue(m_uptake.startUptaking());
      Constants.operatorController.x().whileFalse(m_uptake.stopUptaking());
@@ -83,6 +79,9 @@ public class RobotContainer {
      Constants.operatorController.a().whileTrue(m_shooter.startAmpCommand());
      Constants.operatorController.y().or(Constants.operatorController.a()).whileFalse(m_shooter.stopShooterCommand());
 
+     Constants.driverController.b().whileTrue(m_drivebase.aimAtTarget(m_vision,Constants.driverController.getLeftX(), Constants.driverController.getLeftY()));
+     Constants.driverController.a().whileTrue(m_drivebase.driveToPose(Constants.BLUE_SPEAKER));
+     Constants.driverController.x().whileTrue(m_drivebase.driveToPose(Constants.RED_SPEAKER));
 
   }
 

--- a/src/main/java/frc/robot/subsystems/Swerve/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/Swerve/SwerveSubsystem.java
@@ -320,6 +320,20 @@ public Command sysIdAngleMotorCommand() {
                       false); // Open loop is disabled since it shouldn't be used most of the time.
   }
 
+  public void updateEstimatedPose(VisionSubsystem vision) {
+    // Correct pose estimate with vision measurements
+    var visionEst = vision.getEstimatedGlobalPose();
+    visionEst.ifPresent(
+            est -> {
+                var estPose = est.estimatedPose.toPose2d();
+                // Change our trust in the measurement based on the tags we can see
+                var estStdDevs = vision.getEstimationStdDevs(estPose);
+
+                swerveDrive.addVisionMeasurement(
+                        est.estimatedPose.toPose2d(), est.timestampSeconds, estStdDevs);
+            });
+}
+
   /**
    * Drive the robot given a chassis field oriented velocity.
    *

--- a/src/main/java/frc/robot/subsystems/Swerve/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/Swerve/SwerveSubsystem.java
@@ -25,6 +25,7 @@ import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Filesystem;
 import edu.wpi.first.wpilibj.Timer;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import edu.wpi.first.wpilibj2.command.sysid.SysIdRoutine.Config;
@@ -331,6 +332,10 @@ public Command sysIdAngleMotorCommand() {
 
                 swerveDrive.addVisionMeasurement(
                         est.estimatedPose.toPose2d(), est.timestampSeconds, estStdDevs);
+
+                double[] estimatedPose =  { est.estimatedPose.toPose2d().getX(), est.estimatedPose.toPose2d().getY() };
+                // Send the estimated position of the bot 
+                SmartDashboard.putNumberArray("Estimated Real Robot", estimatedPose);
             });
 }
 

--- a/src/main/java/frc/robot/subsystems/Swerve/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/Swerve/SwerveSubsystem.java
@@ -153,12 +153,12 @@ public class SwerveSubsystem extends SubsystemBase
    * @param camera {@link PhotonCamera} to communicate with.
    * @return A {@link Command} which will run the alignment.
    */
-  public Command aimAtTarget(VisionSubsystem vision) {
+  public Command aimAtTarget(VisionSubsystem vision, double xInput, double yInput) {
     return run(() -> {
       PhotonPipelineResult result = vision.getLatestResult();
       if (result.hasTargets()) {
-        drive(getTargetSpeeds(0,
-                0,
+        drive(getTargetSpeeds(xInput * swerveDrive.get,
+                yInput,
                 Rotation2d.fromDegrees(-result.getBestTarget().getYaw()))); // Not sure if this will work, more math may be required.
       }
     });
@@ -177,13 +177,6 @@ public class SwerveSubsystem extends SubsystemBase
     return new PathPlannerAuto(pathName);
   }
 
-  // public Command spinCounterClockwise()
-  // {
-  //   return run(()->{
-  //         setChassisSpeeds(
-  //           new ChassisSpeeds(0,0,1)
-  //           );});
-  // }
 
   /**
    * Use PathPlanner Path finding to go to a point on the field.
@@ -463,8 +456,6 @@ public Command sysIdAngleMotorCommand() {
    */
   public ChassisSpeeds getTargetSpeeds(double xInput, double yInput, Rotation2d angle)
   {
-    xInput = xInput;
-    yInput = yInput;
     return swerveDrive.swerveController.getTargetSpeeds(xInput,
                                                         yInput,
                                                         angle.getRadians(),

--- a/src/main/java/frc/robot/subsystems/Vision/VisionSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/Vision/VisionSubsystem.java
@@ -32,8 +32,13 @@ import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.numbers.N1;
 import edu.wpi.first.math.numbers.N3;
+import edu.wpi.first.wpilibj.Filesystem;
 import edu.wpi.first.wpilibj.RobotBase;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
+import frc.robot.subsystems.Swerve.SwerveSubsystem;
+import swervelib.SwerveDrive;
+
+import java.io.File;
 import java.util.Optional;
 import org.photonvision.EstimatedRobotPose;
 import org.photonvision.PhotonCamera;
@@ -49,11 +54,21 @@ public class VisionSubsystem {
     private final PhotonPoseEstimator photonEstimator;
     private double lastEstTimestamp = 0;
 
+    private static VisionSubsystem INSTANCE = null;
+
     // Simulation
     private PhotonCameraSim cameraSim;
     private VisionSystemSim visionSim;
 
-    public VisionSubsystem() {
+    public static VisionSubsystem getInstance() {
+        if (INSTANCE == null)
+        {
+        INSTANCE = new VisionSubsystem();
+        }
+        return INSTANCE;
+    }
+
+    private VisionSubsystem() {
         camera = new PhotonCamera(kCameraName);
 
         photonEstimator =


### PR DESCRIPTION
Add two new features to the robot based on the Vision subsystem implemented in #1. Both of these features rely on the built in ability of PhotonVision to track an estimated pose of the robot based on what April tags it can see on the field. It does this with a combination of motor encoders and the tags that are visible, so for this to be accurate we'll have to make sure the webcam and encoders are sending solid data. The added features in this PR are: 

1) Add a "Go to speaker" command on the driver controller. This  command gets the current alliance from the driver station and uses it to determine which speaker to score at. While the command button is held the robot will move to a predetermined pose in front of the speaker so it can make a shot. 
2) Update the `aimAtTarget` command to align the robot with the speaker based on which alliance the team is a part of. 

Some things to verify from this PR when things are on the bot: 

- [ ] Set up April tags on the test Speaker and Amp to verify the positioning can work off of just a few tags
- [ ] Make 100% sure the camera is calibrated correctly 
- [ ] Make sure the speaker/alliance connections are correct (ie are we going to the correct speaker when we push the button?)
- [ ] Find the optimal location to shoot in the speaker and update the Pose in the code
- [ ] Add Poses and aiming commands for the amps 